### PR TITLE
refactor: change how seekbar deals with offsets

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -933,7 +933,7 @@ end
 
 -- Draws seekbar ranges according to user_opts 
 local function draw_seekbar_ranges(element, elem_ass, xp, rh, override_alpha)
-    local handle = ( xp and (mouse_hit_coords(element.hitbox.x1, element.hitbox.y1, element.hitbox.x2, element.hitbox.y2) or state.mouse_down_counter > 0) ) or ( xp and user_opts.handle_always_visible )
+    local handle = xp and rh
     xp = xp or 0
     rh = rh or 0
     local slider_lo = element.layout.slider

--- a/modernz.lua
+++ b/modernz.lua
@@ -975,10 +975,15 @@ local function draw_seekbar_ranges(element, elem_ass, xp, rh, override_alpha)
 end
 
 -- Draw seekbar progress more accurately
-local function draw_seekbar_progress(element, elem_ass, xp)
+local function draw_seekbar_progress(element, elem_ass)
+    local pos = element.slider.posF()
+    if not pos then
+        return
+    end
+    local xp = get_slider_ele_pos_for(element, pos)
     local slider_lo = element.layout.slider
     local elem_geo = element.layout.geometry
-    local progress_offset = slider_lo.gap * (element.slider.posF() / 100) - slider_lo.gap * math.abs(element.slider.posF() / 100 - 1)
+    local progress_offset = slider_lo.gap * (pos / 100) - slider_lo.gap * math.abs(pos / 100 - 1)
     elem_ass:rect_cw(0, slider_lo.gap, xp + progress_offset, elem_geo.h - slider_lo.gap)
 end
 
@@ -1045,7 +1050,7 @@ local function render_elements(master_ass)
                 local s_max = element.slider.max.value
 
                 local xp, rh = draw_seekbar_handle(element, elem_ass) -- handle posistion, handle radius
-                draw_seekbar_progress(element, elem_ass, xp)
+                draw_seekbar_progress(element, elem_ass)
                 draw_seekbar_ranges(element, elem_ass, xp, rh)
 
                 elem_ass:draw_stop()
@@ -1269,14 +1274,8 @@ local function render_persistentprogressbar(master_ass)
                     elem_ass:merge(element.static_ass)
                 end
 
-                local slider_lo = element.layout.slider
-                local elem_geo = element.layout.geometry
                 -- draw pos marker
-                local pos = element.slider.posF()
-                if pos then
-                    local xp = get_slider_ele_pos_for(element, pos)
-                    draw_seekbar_progress(element, elem_ass, xp)
-                end
+                draw_seekbar_progress(element, elem_ass)
 
                 if user_opts.persistentbuffer then
                     draw_seekbar_ranges(element, elem_ass, nil, nil)

--- a/modernz.lua
+++ b/modernz.lua
@@ -933,7 +933,7 @@ end
 
 -- Draws seekbar ranges according to user_opts 
 local function draw_seekbar_ranges(element, elem_ass, xp, rh, override_alpha)
-    local handle = xp and (mouse_hit_coords(element.hitbox.x1, element.hitbox.y1, element.hitbox.x2, element.hitbox.y2) or state.mouse_down_counter > 0)
+    local handle = ( xp and (mouse_hit_coords(element.hitbox.x1, element.hitbox.y1, element.hitbox.x2, element.hitbox.y2) or state.mouse_down_counter > 0) ) or ( xp and user_opts.handle_always_visible )
     xp = xp or 0
     rh = rh or 0
     local slider_lo = element.layout.slider


### PR DESCRIPTION
I got carried away with testing and came up with a solution to deal with the position and size inaccuracies of the seekbar and ranges. It's still a bit messy but seems to work mostly fine. The [solution Sam suggested](https://github.com/Samillion/ModernZ/pull/233#issuecomment-2482938473) is probably better but I'm putting this here as an alternative.

This PR aims to unify the way seekbar rendering deals with the position offset and overall simplify the logic around it to prevent bugs.
## Changes
- Renamed `draw_slider_handle` and `draw_slider_seek_ranges` to `draw_seekbar_handle` and `draw_seekbar_ranges` in order to provide a more accurate description.
- Moved seekbar progress rendering into its own function. This means that all shared functionality between the persistent seekbar and normal seekbar are now handled in functions which should make keeping parity in both bug fixing and features easier.
- Fixed seek range corrections never happening when `handle_always_visible` is set to `false`
- Fixed seekbar progress offset calculation being to large at the beginning and to small at the end.